### PR TITLE
RBAC orgs uses V3 endpoints (no variant)

### DIFF
--- a/commands/access/add.js
+++ b/commands/access/add.js
@@ -12,6 +12,7 @@ function* run(context, heroku) {
   let appInfo = yield heroku.apps(appName).info();
   let output = `Adding ${cli.color.cyan(context.args.email)} access to the app ${cli.color.magenta(appName)}`;
   let request;
+  let orgFlags = [];
 
   if (Utils.isOrgApp(appInfo.owner.email)) {
     let orgName = Utils.getOwner(appInfo.owner.email);
@@ -20,11 +21,12 @@ function* run(context, heroku) {
       path: `/v1/organization/${orgName}`,
       headers: { Accept: 'application/vnd.heroku+json; version=2' }
     });
+    orgFlags = orgInfo.flags;
+  }
 
-    if (orgInfo.flags.indexOf('org-access-controls') !== -1) {
-      output += ` with ${cli.color.green(privileges)} privileges`;
-      if (!privileges) error.exit(1, `Missing argument: privileges`);
-    }
+  if (orgFlags.indexOf('org-access-controls') !== -1) {
+    output += ` with ${cli.color.green(privileges)} privileges`;
+    if (!privileges) error.exit(1, `Missing argument: privileges`);
 
     request = heroku.request({
       method: 'POST',

--- a/test/commands/access/add.js
+++ b/test/commands/access/add.js
@@ -48,7 +48,7 @@ describe('heroku access:add', () => {
     beforeEach(() => {
       cli.mockConsole();
       api = stub.getOrgApp();
-      apiPrivilegesVariant = stub.postCollaboratorsWithPrivileges();
+      apiPrivilegesVariant = stub.postCollaborators();
       apiV2 = stub.orgFlags([]);
     });
     afterEach(()  => nock.cleanAll());


### PR DESCRIPTION
The `3.org-privileges` variant should be used exclusively for FGAC orgs.

This PR changes that.
