### PR TITLE
View is an implicit privilege

### DIFF
--- a/commands/access/add.js
+++ b/commands/access/add.js
@@ -8,7 +8,7 @@ let extend        = require('util')._extend;
 
 function* run(context, heroku) {
   let appName = context.app;
-  let privileges = context.flags.privileges || "";
+  let privileges = context.flags.privileges || '';
   let appInfo = yield heroku.apps(appName).info();
   let output = `Adding ${cli.color.cyan(context.args.email)} access to the app ${cli.color.magenta(appName)}`;
   let request;
@@ -25,8 +25,14 @@ function* run(context, heroku) {
   }
 
   if (orgFlags.indexOf('org-access-controls') !== -1) {
-    output += ` with ${cli.color.green(privileges)} privileges`;
     if (!privileges) error.exit(1, `Missing argument: privileges`);
+
+    privileges = privileges.split(",");
+
+    // Give implicit `view` access
+    privileges.push('view');
+    privileges = privileges.sort();
+    output += ` with ${cli.color.green(privileges)} privileges`;
 
     request = heroku.request({
       method: 'POST',
@@ -36,7 +42,7 @@ function* run(context, heroku) {
       },
       body: {
         user: context.args.email,
-        privileges: privileges.split(",")
+        privileges: privileges
       }
     });
   } else {
@@ -51,7 +57,7 @@ let cmd = {
   needsApp: true,
   command: 'add',
   description: 'Add new users to your app',
-  help: 'heroku access:add user@email.com --app APP # Add a collaborator to your app\n\nheroku access:add user@email.com --app APP --privileges view,deploy,manage,operate # privileges must be comma separated',
+  help: 'heroku access:add user@email.com --app APP # Add a collaborator to your app\n\nheroku access:add user@email.com --app APP --privileges deploy,manage,operate # privileges must be comma separated',
   args: [{name: 'email', optional: false}],
   flags: [
     {name: 'privileges', description: 'list of privileges comma separated', hasValue: true, optional: true}

--- a/commands/access/add.js
+++ b/commands/access/add.js
@@ -1,10 +1,11 @@
 'use strict';
 
-let cli           = require('heroku-cli-util');
-let Utils         = require('../../lib/utils');
-let co            = require('co');
-let error         = require('../../lib/error');
-let extend        = require('util')._extend;
+let cli    = require('heroku-cli-util');
+let _      = require('lodash');
+let Utils  = require('../../lib/utils');
+let co     = require('co');
+let error  = require('../../lib/error');
+let extend = require('util')._extend;
 
 function* run(context, heroku) {
   let appName = context.app;
@@ -31,7 +32,7 @@ function* run(context, heroku) {
 
     // Give implicit `view` access
     privileges.push('view');
-    privileges = privileges.sort();
+    privileges = _.uniq(privileges.sort());
     output += ` with ${cli.color.green(privileges)} privileges`;
 
     request = heroku.request({

--- a/commands/access/index.js
+++ b/commands/access/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let cli       = require('heroku-cli-util');
-let extend      = require('util')._extend;
+let extend    = require('util')._extend;
 let _         = require('lodash');
 let Utils     = require('../../lib/utils');
 let co        = require('co');

--- a/commands/access/update.js
+++ b/commands/access/update.js
@@ -1,9 +1,10 @@
 'use strict';
 
-let cli           = require('heroku-cli-util');
-let Utils         = require('../../lib/utils');
-let error         = require('../../lib/error');
-let co            = require('co');
+let cli   = require('heroku-cli-util');
+let _     = require('lodash');
+let Utils = require('../../lib/utils');
+let error = require('../../lib/error');
+let co    = require('co');
 
 function* run (context, heroku) {
   let appName     = context.app;
@@ -14,7 +15,7 @@ function* run (context, heroku) {
 
   // Give implicit `view` access
   privileges.push('view');
-  privileges = privileges.sort();
+  privileges = _.uniq(privileges.sort());
 
   let request = heroku.request({
     method: 'PATCH',

--- a/commands/access/update.js
+++ b/commands/access/update.js
@@ -7,10 +7,14 @@ let co            = require('co');
 
 function* run (context, heroku) {
   let appName     = context.app;
-  let privileges  = context.flags.privileges;
+  let privileges  = context.flags.privileges.split(",");
   let appInfo = yield heroku.apps(appName).info();
 
   if (!Utils.isOrgApp(appInfo.owner.email)) error.exit(1, `Error: cannot update privileges. The app ${cli.color.cyan(appName)} is not owned by an organization`);
+
+  // Give implicit `view` access
+  privileges.push('view');
+  privileges = privileges.sort();
 
   let request = heroku.request({
     method: 'PATCH',
@@ -19,7 +23,7 @@ function* run (context, heroku) {
       Accept: 'application/vnd.heroku+json; version=3.org-privileges',
     },
     body: {
-      privileges: privileges.split(",")
+      privileges: privileges
     }
   });
   yield cli.action(`Updating ${context.args.email} in application ${cli.color.cyan(appName)} with ${privileges} privileges`, request);
@@ -31,11 +35,11 @@ module.exports = {
   needsApp: true,
   command: 'update',
   description: 'Update existing collaborators in an org app',
-  help: 'heroku access:update user@email.com --app APP --privileges deploy,manage,operate,view',
+  help: 'heroku access:update user@email.com --app APP --privileges deploy,manage,operate',
   args:  [{name: 'email', optional: false}],
   flags: [
     {
-      name: 'privileges', hasValue: true, required: true, description: 'comma-delimited list of privileges to update (deploy,manage,operate,view)'
+      name: 'privileges', hasValue: true, required: true, description: 'comma-delimited list of privileges to update (deploy,manage,operate)'
     },
   ],
   run: cli.command(co.wrap(run))

--- a/test/commands/access/add.js
+++ b/test/commands/access/add.js
@@ -14,16 +14,16 @@ describe('heroku access:add', () => {
     beforeEach(() => {
       cli.mockConsole();
       api = stub.getOrgApp();
-      apiPrivilegesVariant = stub.postCollaboratorsWithPrivileges(['view', 'deploy']);
+      apiPrivilegesVariant = stub.postCollaboratorsWithPrivileges(['deploy', 'view']);
       apiV2 = stub.orgFlags(['org-access-controls']);
 
     });
     afterEach(()  => nock.cleanAll());
 
-    it('adds user to the app with privileges', () => {
-      return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'view,deploy' }})
+    it('adds user to the app with privileges, and view is implicit', () => {
+      return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'deploy' }})
       .then(() => expect(``).to.eq(cli.stdout))
-        .then(() => expect(`Adding raulb@heroku.com access to the app myapp with view,deploy privileges... done\n`).to.eq(cli.stderr))
+        .then(() => expect(`Adding raulb@heroku.com access to the app myapp with deploy,view privileges... done\n`).to.eq(cli.stderr))
         .then(() => api.done())
         .then(() => apiV2.done())
         .then(() => apiPrivilegesVariant.done());

--- a/test/commands/access/add.js
+++ b/test/commands/access/add.js
@@ -29,6 +29,15 @@ describe('heroku access:add', () => {
         .then(() => apiPrivilegesVariant.done());
     });
 
+    it('adds user to the app with privileges, even specifying the view privilege', () => {
+      return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'deploy,view' }})
+      .then(() => expect(``).to.eq(cli.stdout))
+        .then(() => expect(`Adding raulb@heroku.com access to the app myapp with deploy,view privileges... done\n`).to.eq(cli.stderr))
+        .then(() => api.done())
+        .then(() => apiV2.done())
+        .then(() => apiPrivilegesVariant.done());
+    });
+
     it('raises an error when privileges are not specified', () => {
       error.exit.mock();
 

--- a/test/commands/access/update.js
+++ b/test/commands/access/update.js
@@ -30,6 +30,27 @@ describe('heroku access:update', () => {
         .then(() => api.done())
         .then(() => apiPrivilegesVariant.done());
     });
+
+    it('updates the app privileges, even specifying view as a privilege', () => {
+      let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp')
+      .reply(200, {
+        name: 'myapp',
+        owner: { email: 'myorg@herokumanager.com' }
+      });
+      let apiPrivilegesVariant = nock('https://api.heroku.com:443', {
+        reqheaders: {Accept: 'application/vnd.heroku+json; version=3.org-privileges'}
+      })
+      .patch('/organizations/apps/myapp/collaborators/raulb@heroku.com', {
+        privileges: ['deploy', 'view']
+      }).reply(200);
+
+      return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'deploy,view' }})
+      .then(() => expect(``).to.eq(cli.stdout))
+        .then(() => expect(`Updating raulb@heroku.com in application myapp with deploy,view privileges... done\n`).to.eq(cli.stderr))
+        .then(() => api.done())
+        .then(() => apiPrivilegesVariant.done());
+    });
   });
 
   context('with a non org app', () => {

--- a/test/commands/access/update.js
+++ b/test/commands/access/update.js
@@ -10,7 +10,7 @@ describe('heroku access:update', () => {
     beforeEach(() => cli.mockConsole());
     afterEach(()  => nock.cleanAll());
 
-    it('updates the app privileges', () => {
+    it('updates the app privileges, view being implicit', () => {
       let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp')
       .reply(200, {
@@ -21,12 +21,12 @@ describe('heroku access:update', () => {
         reqheaders: {Accept: 'application/vnd.heroku+json; version=3.org-privileges'}
       })
       .patch('/organizations/apps/myapp/collaborators/raulb@heroku.com', {
-        privileges: ['view', 'deploy']
+        privileges: ['deploy', 'view']
       }).reply(200);
 
-      return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'view,deploy' }})
+      return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'deploy' }})
       .then(() => expect(``).to.eq(cli.stdout))
-        .then(() => expect(`Updating raulb@heroku.com in application myapp with view,deploy privileges... done\n`).to.eq(cli.stderr))
+        .then(() => expect(`Updating raulb@heroku.com in application myapp with deploy,view privileges... done\n`).to.eq(cli.stderr))
         .then(() => api.done())
         .then(() => apiPrivilegesVariant.done());
     });


### PR DESCRIPTION
The API is not requiring the `view` privilege at the moment when updating, though we make that implicit in the dashboard.

This PR gives the view privilege implicitly for the `add` and `update` commands.

More info: https://www.pivotaltracker.com/story/show/114895883
