### PR TITLE
Warn users when going over free team limit

### DIFF
--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -11,7 +11,9 @@ function* run (context, heroku) {
   let role  = context.flags.role;
   let members = yield heroku.get(`/organizations/${org}/members`);
   let features = yield heroku.get('/account/features');
-  let orgCreationFeature = features.find(function(feature) { return feature.name === 'standard-org-creation'});
+  let orgCreationFeature = features.find(function(feature) {
+    return feature.name === 'standard-org-creation';
+  });
 
   let request = heroku.request({
     method: 'PUT',

--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -5,6 +5,8 @@ let co     = require('co');
 let extend = require('util')._extend;
 
 function* run (context, heroku) {
+  // Users receive `You'll be billed monthly for teams over 5 members.`
+  // message when going over the FREE_TEAM_LIMIT
   const FREE_TEAM_LIMIT = 5;
   let org   = context.org;
   let email = context.args.email;

--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -5,9 +5,13 @@ let co     = require('co');
 let extend = require('util')._extend;
 
 function* run (context, heroku) {
+  const FREE_TEAM_LIMIT = 5;
   let org   = context.org;
   let email = context.args.email;
   let role  = context.flags.role;
+  let members = yield heroku.get(`/organizations/${org}/members`);
+  let features = yield heroku.get('/account/features');
+  let orgCreationFeature = features.find(function(feature) { return feature.name === 'standard-org-creation'});
 
   let request = heroku.request({
     method: 'PUT',
@@ -15,6 +19,9 @@ function* run (context, heroku) {
     body:   {email, role},
   });
   yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(org)} as ${cli.color.green(role)}`, request);
+  if ((members.length === FREE_TEAM_LIMIT) && orgCreationFeature) {
+    cli.log("You'll be billed monthly for teams over 5 members.");
+  }
 }
 
 let cmd = {

--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -9,7 +9,6 @@ function* run (context, heroku) {
   let org   = context.org;
   let email = context.args.email;
   let role  = context.flags.role;
-  let members = yield heroku.get(`/organizations/${org}/members`);
   let features = yield heroku.get('/account/features');
   let orgCreationFeature = features.find(function(feature) {
     return feature.name === 'standard-org-creation';
@@ -21,7 +20,9 @@ function* run (context, heroku) {
     body:   {email, role},
   });
   yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(org)} as ${cli.color.green(role)}`, request);
-  if ((members.length === FREE_TEAM_LIMIT) && orgCreationFeature) {
+
+  let members = yield heroku.get(`/organizations/${org}/members`);
+  if ((members.length === (FREE_TEAM_LIMIT + 1)) && orgCreationFeature) {
     cli.log("You'll be billed monthly for teams over 5 members.");
   }
 }

--- a/test/commands/members/add.js
+++ b/test/commands/members/add.js
@@ -38,7 +38,7 @@ describe('heroku members:add', () => {
     });
 
     it('does not warn the user when over the free org limit', () => {
-      stubGet.variableSizeOrgMembers(6);
+      stubGet.variableSizeOrgMembers(7);
       let api = nock('https://api.heroku.com:443')
       .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
       .reply(200);
@@ -50,7 +50,7 @@ describe('heroku members:add', () => {
     });
 
     it('does warn the user when at the free org limit', () => {
-      stubGet.variableSizeOrgMembers(5);
+      stubGet.variableSizeOrgMembers(6);
       let api = nock('https://api.heroku.com:443')
       .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
       .reply(200);

--- a/test/commands/members/add.js
+++ b/test/commands/members/add.js
@@ -1,18 +1,64 @@
 'use strict';
 
 let cmd = require('../../../commands/members/add').add;
+let stubGet = require('../../stub/get');
 
 describe('heroku members:add', () => {
   beforeEach(() => cli.mockConsole());
   afterEach(()  => nock.cleanAll());
 
   it('adds a member to an org', () => {
+    stubGet.variableSizeOrgMembers(1);
+    stubGet.userFeatureFlags([]);
     let api = nock('https://api.heroku.com:443')
     .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
     .reply(200);
+
     return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
     .then(() => expect(``).to.eq(cli.stdout))
     .then(() => expect(`Adding foo@foo.com to myorg as admin... done\n`).to.eq(cli.stderr))
     .then(() => api.done());
+  });
+
+  context('adding a member with the standard org creation flag', () => {
+    beforeEach(() => {
+      stubGet.userFeatureFlags([{name: 'standard-org-creation'}]);
+    });
+
+    it('does not warn the user when under the free org limit', () => {
+      stubGet.variableSizeOrgMembers(1);
+      let api = nock('https://api.heroku.com:443')
+      .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
+      .reply(200);
+
+      return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
+      .then(() => expect(``).to.eq(cli.stdout))
+      .then(() => expect(`Adding foo@foo.com to myorg as admin... done\n`).to.eq(cli.stderr))
+      .then(() => api.done());
+    });
+
+    it('does not warn the user when over the free org limit', () => {
+      stubGet.variableSizeOrgMembers(6);
+      let api = nock('https://api.heroku.com:443')
+      .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
+      .reply(200);
+
+      return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
+      .then(() => expect(``).to.eq(cli.stdout))
+      .then(() => expect(`Adding foo@foo.com to myorg as admin... done\n`).to.eq(cli.stderr))
+      .then(() => api.done());
+    });
+
+    it('does warn the user when at the free org limit', () => {
+      stubGet.variableSizeOrgMembers(5);
+      let api = nock('https://api.heroku.com:443')
+      .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
+      .reply(200);
+
+      return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
+      .then(() => expect(`You'll be billed monthly for teams over 5 members.\n`).to.eq(cli.stdout))
+      .then(() => expect(`Adding foo@foo.com to myorg as admin... done\n`).to.eq(cli.stderr))
+      .then(() => api.done());
+    });
   });
 });

--- a/test/stub/get.js
+++ b/test/stub/get.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function appCollaborators() {
   return nock('https://api.heroku.com:443')
   .get('/apps/myapp/collaborators')
@@ -82,19 +84,31 @@ function orgMembers() {
   return nock('https://api.heroku.com:443')
   .get('/organizations/myorg/members')
   .reply(200, [
-      {
-        email: 'raulb@heroku.com', role: 'admin',
-        user: { email: 'raulb@heroku.com' }
-      },
-      {
-        email: 'bob@heroku.com', role: 'viewer',
-        user: { email: 'bob@heroku.com' }
-      },
-      {
-        email: 'peter@heroku.com', role: 'collaborator',
-        user: { email: 'peter@heroku.com' }
-      }
+    {
+      email: 'raulb@heroku.com', role: 'admin',
+      user: { email: 'raulb@heroku.com' }
+    },
+    {
+      email: 'bob@heroku.com', role: 'viewer',
+      user: { email: 'bob@heroku.com' }
+    },
+    {
+      email: 'peter@heroku.com', role: 'collaborator',
+      user: { email: 'peter@heroku.com' }
+    }
   ]);
+}
+
+function variableSizeOrgMembers(orgSize) {
+  orgSize = (typeof(orgSize) === 'undefined') ? 1 : orgSize;
+  let orgMembers = [];
+  for(let i = 0; i < orgSize; i++) {
+    orgMembers.push({email: `test${i}@heroku.com`, role: 'admin',
+      user: { email: `test${i}@heroku.com` }});
+  }
+  return nock('https://api.heroku.com:443')
+  .get('/organizations/myorg/members')
+  .reply(200, orgMembers);
 }
 
 function personalApp() {
@@ -106,6 +120,12 @@ function personalApp() {
   });
 }
 
+function userFeatureFlags(flags) {
+  return nock('https://api.heroku.com:443')
+  .get('/account/features')
+  .reply(200, flags);
+}
+
 module.exports = {
   appCollaborators: appCollaborators,
   appPrivileges: appPrivileges,
@@ -114,5 +134,7 @@ module.exports = {
   orgAppCollaboratorsWithPrivileges: orgAppCollaboratorsWithPrivileges,
   orgFlags: orgFlags,
   orgMembers: orgMembers,
-  personalApp: personalApp
+  personalApp: personalApp,
+  userFeatureFlags: userFeatureFlags,
+  variableSizeOrgMembers: variableSizeOrgMembers
 };


### PR DESCRIPTION
With the release of self serv orgs, users will be charged monthly if they have over 5 users in their team. This PR will ensure they are warned about crossing this threshold when they do via CLI. For now, this warning is hidden behind a feature flag.
