### PR TITLE
Removes special checks for viewer role

### DIFF
--- a/commands/access/index.js
+++ b/commands/access/index.js
@@ -21,7 +21,7 @@ function printAccess (app, collaborators) {
   .reject(c => /herokumanager\.com$/.test(c.user.email))
   .map(collab => {
     let email = collab.user.email;
-    let role = Utils.roleName(collab.role);
+    let role = collab.role;
     let data = { email: email, role: role || 'collaborator' };
 
     if (showPrivileges) {
@@ -32,7 +32,7 @@ function printAccess (app, collaborators) {
 
   let columns = [
     {key: 'email', label: 'Email', format: e => cli.color.cyan(e)},
-    {key: 'role', label: 'Role', format: r => cli.color.green(Utils.roleName(r))}
+    {key: 'role', label: 'Role', format: r => cli.color.green(r)}
   ];
   if (showPrivileges) columns.push({key: 'privileges', label: 'Privileges'});
   cli.table(collaborators, {printHeader: false, columns});

--- a/commands/members/index.js
+++ b/commands/members/index.js
@@ -3,12 +3,11 @@
 let cli     = require('heroku-cli-util');
 let co      = require('co');
 let _       = require('lodash');
-let Utils   = require('../../lib/utils');
 
 function* run (context, heroku) {
   let members = yield heroku.get(`/organizations/${context.org}/members`);
   members = _.sortBy(members, 'email');
-  if (context.flags.role) members = members.filter(m => Utils.roleName(m.role) === context.flags.role);
+  if (context.flags.role) members = members.filter(m => m.role === context.flags.role);
   if (context.flags.json) {
     cli.log(JSON.stringify(members, null, 2));
   } else if (members.length === 0) {
@@ -20,7 +19,7 @@ function* run (context, heroku) {
       printHeader: false,
       columns: [
         {key: 'email', label: 'Email', format: e => cli.color.cyan(e)},
-        {key: 'role', label: 'Role', format: r => cli.color.green(Utils.roleName(r))},
+        {key: 'role', label: 'Role', format: r => cli.color.green(r)},
       ]
     });
   }

--- a/commands/orgs/index.js
+++ b/commands/orgs/index.js
@@ -3,7 +3,6 @@
 let cli     = require('heroku-cli-util');
 let co      = require('co');
 let _       = require('lodash');
-let Utils   = require('../../lib/utils');
 
 function printJSON (orgs) {
   cli.log(JSON.stringify(orgs, null, 2));
@@ -14,7 +13,7 @@ function print (orgs) {
   cli.table(orgs, {
     columns: [
       {key: 'name', label: 'Organization', format: o => cli.color.green(o)},
-      {key: 'role', label: 'Role', format: r => Utils.roleName(r)},
+      {key: 'role', label: 'Role', format: r => r},
     ],
     printHeader: false
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,12 +4,6 @@ var isOrgApp = function (owner) {
 
 module.exports.isOrgApp = isOrgApp;
 
-var roleName = function(role) {
-  return role === 'viewer' ? 'member' : role;
-};
-
-module.exports.roleName = roleName;
-
 var getOwner = function(owner) {
   if (isOrgApp(owner)) {
     return owner.split('@herokumanager.com')[0];

--- a/test/commands/members/index.js
+++ b/test/commands/members/index.js
@@ -34,7 +34,7 @@ b@heroku.com  collaborator
     .then(() => api.done());
   });
 
-  it('shows member when role is viewer', () => {
+  it('does not show member when role is viewer', () => {
     let api = nock('https://api.heroku.com:443')
     .get('/organizations/myorg/members')
     .reply(200, [
@@ -44,7 +44,7 @@ b@heroku.com  collaborator
     return cmd.run({org: 'myorg', flags: {}})
     .then(() => expect(
 `a@heroku.com  admin
-b@heroku.com  member
+b@heroku.com  viewer
 `).to.eq(cli.stdout))
     .then(() => expect(``).to.eq(cli.stderr))
     .then(() => api.done());
@@ -55,7 +55,7 @@ b@heroku.com  member
     .get('/organizations/myorg/members')
     .reply(200, [
       {email: 'a@heroku.com', role: 'admin'},
-      {email: 'b@heroku.com', role: 'viewer'},
+      {email: 'b@heroku.com', role: 'member'},
     ]);
     return cmd.run({org: 'myorg', flags: {role: 'member'}})
     .then(() => expect(
@@ -85,7 +85,7 @@ b@heroku.com  member
     .get('/organizations/myorg/members')
     .reply(200, [
       {email: 'a@heroku.com', role: 'admin'},
-      {email: 'b@heroku.com', role: 'viewer'},
+      {email: 'b@heroku.com', role: 'member'},
     ]);
     return cmd.run({org: 'myorg', flags: {role: 'member'}})
     .then(() => expect(

--- a/test/commands/members/index.js
+++ b/test/commands/members/index.js
@@ -34,22 +34,6 @@ b@heroku.com  collaborator
     .then(() => api.done());
   });
 
-  it('does not show member when role is viewer', () => {
-    let api = nock('https://api.heroku.com:443')
-    .get('/organizations/myorg/members')
-    .reply(200, [
-      {email: 'a@heroku.com', role: 'admin'},
-      {email: 'b@heroku.com', role: 'viewer'},
-    ]);
-    return cmd.run({org: 'myorg', flags: {}})
-    .then(() => expect(
-`a@heroku.com  admin
-b@heroku.com  viewer
-`).to.eq(cli.stdout))
-    .then(() => expect(``).to.eq(cli.stderr))
-    .then(() => api.done());
-  });
-
   it('filters members by role', () => {
     let api = nock('https://api.heroku.com:443')
     .get('/organizations/myorg/members')

--- a/test/commands/orgs/index.js
+++ b/test/commands/orgs/index.js
@@ -21,18 +21,4 @@ org b         admin
       .then(() => expect(``).to.eq(cli.stderr))
       .then(() => api.done());
   });
-
-  it('does not show member when role is viewer', () => {
-    let api = nock('https://api.heroku.com:443')
-    .get('/organizations')
-    .reply(200, [
-      {name: 'org a', role: 'viewer'}
-    ]);
-    return cmd.run({flags: {}})
-    .then(() => expect(
-`org a         viewer
-`).to.eq(cli.stdout))
-      .then(() => expect(``).to.eq(cli.stderr))
-      .then(() => api.done());
-  });
 });

--- a/test/commands/orgs/index.js
+++ b/test/commands/orgs/index.js
@@ -22,7 +22,7 @@ org b         admin
       .then(() => api.done());
   });
 
-  it('shows member when role is viewer', () => {
+  it('does not show member when role is viewer', () => {
     let api = nock('https://api.heroku.com:443')
     .get('/organizations')
     .reply(200, [
@@ -30,7 +30,7 @@ org b         admin
     ]);
     return cmd.run({flags: {}})
     .then(() => expect(
-`org a         member
+`org a         viewer
 `).to.eq(cli.stdout))
       .then(() => expect(``).to.eq(cli.stderr))
       .then(() => api.done());

--- a/test/stub/get.js
+++ b/test/stub/get.js
@@ -64,7 +64,7 @@ function orgAppCollaboratorsWithPrivileges() {
     },
     {
       privileges: [ { name: 'deploy' }, { name: 'view' } ],
-      role: 'viewer',
+      role: 'member',
       user: { email: 'bob@heroku.com' }
     }
   ]);


### PR DESCRIPTION
This can also be removed entirely:
- https://github.com/heroku/heroku-orgs/blob/removes-viewer-special-case/test/commands/members/index.js#L37-L51
- https://github.com/heroku/heroku-orgs/blob/removes-viewer-special-case/test/commands/orgs/index.js#L25-L37

This is just to prove that we're not filtering out any type of role now.
