### PR TITLE
Fix error format on forbidden

### DIFF
--- a/commands/apps/join.js
+++ b/commands/apps/join.js
@@ -7,14 +7,9 @@ function* run (context, heroku) {
   let request = heroku.request({
     method:     'POST',
     path:       `/v1/app/${context.app}/join`,
-    parseJSON:  false,
     headers:    {Accept: 'application/json'}
   });
-  try {
-    yield cli.action(`Joining ${cli.color.cyan(context.app)}`, request);
-  } catch (err) {
-    throw err.body ? new Error(err.body) : err;
-  }
+  yield cli.action(`Joining ${cli.color.cyan(context.app)}`, request);
 }
 
 let cmd = {

--- a/test/commands/apps/join.js
+++ b/test/commands/apps/join.js
@@ -15,4 +15,22 @@ describe('heroku apps:join', () => {
       .then(() => expect(`Joining myapp... done\n`).to.eq(cli.stderr))
       .then(() => api.done());
   });
+
+  it('is forbidden from joining the app', () => {
+    nock('https://api.heroku.com:443')
+    .post('/v1/app/myapp/join')
+    .reply(403, {"id":"forbidden","error":"You do not have access to the organization heroku-tools."});
+
+    let thrown = false;
+
+    return cmd.run({app: 'myapp'})
+    .catch(function(err) {
+      thrown = true;
+      expect(err.body.error).to.eq("You do not have access to the organization heroku-tools.");
+    })
+    .then(function() {
+      expect(thrown).to.eq(true);
+    });
+  });
+
 });


### PR DESCRIPTION
@dickeyxxx when you get back, review me, fixes the following output.

```
 ▸    {"id":"forbidden","error":"You do not have access to the organization heroku-tools."}
```
