### PR TITLE
updated heroku-cli-util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "5.4"
+  - "6.2.0"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 6.2.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 6.2.0

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "co": "4.6.0",
-    "heroku-cli-util": "6.0.0",
+    "heroku-cli-util": "6.0.11",
     "lodash": "4.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@raulb or @dickeyxxx could you please review?  In the bump between `6.0.0` and `6.0.11` the `cli.command` function stopped wrapping the passed in function in `co.wrap`.  All the tests pass and I grep'ed through the code to make sure everything was wrapped in co, and it looked good to me.  I just wanted another set of eyes to make sure I did not miss anything, as an untested command that relied on this behavior could break things.
