### PR TITLE
Requires confirmation for transfers to personal accounts

### DIFF
--- a/commands/apps/transfer.js
+++ b/commands/apps/transfer.js
@@ -28,6 +28,7 @@ function * run (context, heroku) {
   let app = context.app
   let recipient = context.args.recipient
 
+  // App transfers in bulk
   if (context.flags.bulk) {
     let allApps = yield heroku.get('/apps')
     let selectedApps = yield getAppsToTransfer(_.sortBy(allApps, 'name'))
@@ -40,7 +41,7 @@ function * run (context, heroku) {
           heroku: heroku,
           appName: app.name,
           recipient: recipient,
-          personalAppTransfer: Utils.isValidEmail(recipient) && !Utils.isOrgApp(app.owner),
+          interPersonalTransfer: Utils.isValidEmail(recipient) && !Utils.isOrgApp(app.owner),
           bulk: true
         })
         yield appTransfer.start()
@@ -48,13 +49,19 @@ function * run (context, heroku) {
         cli.error(err)
       }
     }
-  } else {
+  } else { // Single app transfer
     let appInfo = yield heroku.get(`/apps/${app}`)
+
+    // Shows warning when app is transferred from a team/org to a personal account
+    if (Utils.isValidEmail(recipient) && Utils.isOrgApp(appInfo.owner.email)) {
+      yield cli.confirmApp(app, context.flags.confirm, 'All collaborators will be removed from this app')
+    }
+
     let appTransfer = new AppTransfer({
       heroku: heroku,
       appName: appInfo.name,
       recipient: recipient,
-      personalAppTransfer: Utils.isValidEmail(recipient) && !Utils.isOrgApp(appInfo.owner.email)
+      interPersonalTransfer: Utils.isValidEmail(recipient) && !Utils.isOrgApp(appInfo.owner.email)
     })
     yield appTransfer.start()
 

--- a/commands/apps/transfer.js
+++ b/commands/apps/transfer.js
@@ -41,7 +41,7 @@ function * run (context, heroku) {
           heroku: heroku,
           appName: app.name,
           recipient: recipient,
-          interPersonalTransfer: Utils.isValidEmail(recipient) && !Utils.isOrgApp(app.owner),
+          personalToPersonal: Utils.isValidEmail(recipient) && !Utils.isOrgApp(app.owner),
           bulk: true
         })
         yield appTransfer.start()
@@ -61,7 +61,7 @@ function * run (context, heroku) {
       heroku: heroku,
       appName: appInfo.name,
       recipient: recipient,
-      interPersonalTransfer: Utils.isValidEmail(recipient) && !Utils.isOrgApp(appInfo.owner.email)
+      personalToPersonal: Utils.isValidEmail(recipient) && !Utils.isOrgApp(appInfo.owner.email)
     })
     yield appTransfer.start()
 

--- a/lib/app_transfer.js
+++ b/lib/app_transfer.js
@@ -8,18 +8,18 @@ class AppTransfer {
    * @param {Object} options.heroku - instance of heroku-client
    * @param {string} options.appName - application that is being transferred
    * @param {string} options.recipient - recipient of the transfer
-   * @param {boolean} options.interPersonalTransfer - determines if it is a transfer between individual accounts
+   * @param {boolean} options.personalToPersonal - determines if it is a transfer between individual accounts
   */
   constructor (opts) {
     this.opts = opts
     this.heroku = this.opts.heroku
     this.appName = this.opts.appName
     this.recipient = this.opts.recipient
-    this.interPersonalTransfer = this.opts.interPersonalTransfer
+    this.personalToPersonal = this.opts.personalToPersonal
 
-    if (this.interPersonalTransfer === undefined) this.interPersonalTransfer = true
+    if (this.personalToPersonal === undefined) this.personalToPersonal = true
 
-    if (this.interPersonalTransfer) {
+    if (this.personalToPersonal) {
       this.body = { app: this.appName, recipient: this.recipient }
       this.transferMsg = `Initiating transfer of ${cli.color.app(this.appName)}`
       if (!this.opts.bulk) this.transferMsg += ` to ${cli.color.magenta(this.recipient)}`

--- a/lib/app_transfer.js
+++ b/lib/app_transfer.js
@@ -8,18 +8,18 @@ class AppTransfer {
    * @param {Object} options.heroku - instance of heroku-client
    * @param {string} options.appName - application that is being transferred
    * @param {string} options.recipient - recipient of the transfer
-   * @param {boolean} options.personalAppTransfer - determines if it is a transfer between individual accounts
+   * @param {boolean} options.interPersonalTransfer - determines if it is a transfer between individual accounts
   */
   constructor (opts) {
     this.opts = opts
     this.heroku = this.opts.heroku
     this.appName = this.opts.appName
     this.recipient = this.opts.recipient
-    this.personalAppTransfer = this.opts.personalAppTransfer
+    this.interPersonalTransfer = this.opts.interPersonalTransfer
 
-    if (this.personalAppTransfer === undefined) this.personalAppTransfer = true
+    if (this.interPersonalTransfer === undefined) this.interPersonalTransfer = true
 
-    if (this.personalAppTransfer) {
+    if (this.interPersonalTransfer) {
       this.body = { app: this.appName, recipient: this.recipient }
       this.transferMsg = `Initiating transfer of ${cli.color.app(this.appName)}`
       if (!this.opts.bulk) this.transferMsg += ` to ${cli.color.magenta(this.recipient)}`

--- a/test/commands/apps/transfer.js
+++ b/test/commands/apps/transfer.js
@@ -73,7 +73,7 @@ Transferring myapp... done
         return Promise.resolve({choices: [{ name: 'myapp', owner: 'foo@foo.com' }]})
       }
 
-      let api = stubPost.personalAppTransfer()
+      let api = stubPost.interPersonalTransfer()
       return cmd.run({args: {recipient: 'raulb@heroku.com'}, flags: {bulk: true}})
         .then(function () {
           api.done()
@@ -91,7 +91,7 @@ Initiating transfer of myapp... email sent
     })
 
     it('transfers the app to a personal account', () => {
-      let api = stubPost.personalAppTransfer()
+      let api = stubPost.interPersonalTransfer()
       return cmd.run({app: 'myapp', args: {recipient: 'raulb@heroku.com'}, flags: {}})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Initiating transfer of myapp to raulb@heroku.com... email sent
@@ -114,9 +114,9 @@ Initiating transfer of myapp... email sent
       stubGet.orgApp()
     })
 
-    it('transfers the app to a personal account', () => {
+    it('transfers the app to a personal account confirming app name', () => {
       let api = stubPatch.orgAppTransfer()
-      return cmd.run({app: 'myapp', args: {recipient: 'team'}, flags: {}})
+      return cmd.run({app: 'myapp', args: {recipient: 'team'}, flags: { confirm: 'myapp' }})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Transferring myapp to team... done
 `).to.eq(cli.stderr))
@@ -133,7 +133,7 @@ Initiating transfer of myapp... email sent
     })
 
     it('transfers and locks the app if --locked is passed', () => {
-      let api = stubPatch.personalAppTransfer()
+      let api = stubPatch.orgAppTransfer()
 
       let lockedAPI = nock('https://api.heroku.com:443')
         .get('/organizations/apps/myapp')
@@ -141,9 +141,9 @@ Initiating transfer of myapp... email sent
         .patch('/organizations/apps/myapp', {locked: true})
         .reply(200)
 
-      return cmd.run({app: 'myapp', args: {recipient: 'raulb@heroku.com'}, flags: {locked: true}})
+      return cmd.run({app: 'myapp', args: {recipient: 'team'}, flags: { locked: true }})
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Transferring myapp to raulb@heroku.com... done
+        .then(() => expect(`Transferring myapp to team... done
 Locking myapp... done
 `).to.eq(cli.stderr))
         .then(() => api.done())

--- a/test/commands/apps/transfer.js
+++ b/test/commands/apps/transfer.js
@@ -73,7 +73,7 @@ Transferring myapp... done
         return Promise.resolve({choices: [{ name: 'myapp', owner: 'foo@foo.com' }]})
       }
 
-      let api = stubPost.interPersonalTransfer()
+      let api = stubPost.personalToPersonal()
       return cmd.run({args: {recipient: 'raulb@heroku.com'}, flags: {bulk: true}})
         .then(function () {
           api.done()
@@ -91,7 +91,7 @@ Initiating transfer of myapp... email sent
     })
 
     it('transfers the app to a personal account', () => {
-      let api = stubPost.interPersonalTransfer()
+      let api = stubPost.personalToPersonal()
       return cmd.run({app: 'myapp', args: {recipient: 'raulb@heroku.com'}, flags: {}})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Initiating transfer of myapp to raulb@heroku.com... email sent

--- a/test/stub/patch.js
+++ b/test/stub/patch.js
@@ -8,7 +8,7 @@ function orgAppTransfer () {
     .reply(200, { name: 'myapp', owner: { email: 'team@herokumanager.com' } })
 }
 
-function personalAppTransfer () {
+function interPersonalTransfer () {
   return nock('https://api.heroku.com:443')
     .patch('/organizations/apps/myapp', {owner: 'raulb@heroku.com'})
     .reply(200, { name: 'myapp', owner: { email: 'raulb@heroku.com' } })
@@ -16,5 +16,5 @@ function personalAppTransfer () {
 
 module.exports = {
   orgAppTransfer: orgAppTransfer,
-  personalAppTransfer: personalAppTransfer
+  interPersonalTransfer: interPersonalTransfer
 }

--- a/test/stub/patch.js
+++ b/test/stub/patch.js
@@ -8,7 +8,7 @@ function orgAppTransfer () {
     .reply(200, { name: 'myapp', owner: { email: 'team@herokumanager.com' } })
 }
 
-function interPersonalTransfer () {
+function personalToPersonal () {
   return nock('https://api.heroku.com:443')
     .patch('/organizations/apps/myapp', {owner: 'raulb@heroku.com'})
     .reply(200, { name: 'myapp', owner: { email: 'raulb@heroku.com' } })
@@ -16,5 +16,5 @@ function interPersonalTransfer () {
 
 module.exports = {
   orgAppTransfer: orgAppTransfer,
-  interPersonalTransfer: interPersonalTransfer
+  personalToPersonal: personalToPersonal
 }

--- a/test/stub/post.js
+++ b/test/stub/post.js
@@ -19,7 +19,7 @@ function collaboratorsWithPrivileges (privileges) {
     }).reply(200)
 }
 
-function interPersonalTransfer () {
+function personalToPersonal () {
   return nock('https://api.heroku.com:443')
     .post('/account/app-transfers', {app: 'myapp', recipient: 'raulb@heroku.com'})
     .reply(200, {state: 'pending'})
@@ -28,5 +28,5 @@ function interPersonalTransfer () {
 module.exports = {
   collaborators: collaborators,
   collaboratorsWithPrivileges: collaboratorsWithPrivileges,
-  interPersonalTransfer: interPersonalTransfer
+  personalToPersonal: personalToPersonal
 }

--- a/test/stub/post.js
+++ b/test/stub/post.js
@@ -19,7 +19,7 @@ function collaboratorsWithPrivileges (privileges) {
     }).reply(200)
 }
 
-function personalAppTransfer () {
+function interPersonalTransfer () {
   return nock('https://api.heroku.com:443')
     .post('/account/app-transfers', {app: 'myapp', recipient: 'raulb@heroku.com'})
     .reply(200, {state: 'pending'})
@@ -28,5 +28,5 @@ function personalAppTransfer () {
 module.exports = {
   collaborators: collaborators,
   collaboratorsWithPrivileges: collaboratorsWithPrivileges,
-  personalAppTransfer: personalAppTransfer
+  interPersonalTransfer: interPersonalTransfer
 }


### PR DESCRIPTION
In transfers from team/org to personal accounts, all collaborators lose access, and only the new recipient remains.

This change starts requiring confirmation when that's the case.

Example:

```
$ heroku apps:transfer personal@email.com -a my-org-app
 ▸    All collaborators will be removed from this app
 ▸    To proceed, type warm-brushlands-1635 or re-run this command with --confirm my-org-app
> my-org-app
Transferring ⬢ my-org-app to personal@email.com... done
```
