### PR TITLE
Updates to v3 organization/features

### DIFF
--- a/commands/access/add.js
+++ b/commands/access/add.js
@@ -13,19 +13,14 @@ function * run (context, heroku) {
   let appInfo = yield heroku.get(`/apps/${appName}`)
   let output = `Adding ${cli.color.cyan(context.args.email)} access to the app ${cli.color.magenta(appName)}`
   let request
-  let orgFlags = []
+  let orgFeatures = []
 
   if (Utils.isOrgApp(appInfo.owner.email)) {
     let orgName = Utils.getOwner(appInfo.owner.email)
-    let orgInfo = yield heroku.request({
-      method: 'GET',
-      path: `/v1/organization/${orgName}`,
-      headers: { Accept: 'application/vnd.heroku+json; version=2' }
-    })
-    orgFlags = orgInfo.flags
+    orgFeatures = yield heroku.get(`/organizations/${orgName}/features`)
   }
 
-  if (_.includes(orgFlags, 'org-access-controls')) {
+  if (_.includes(_.map(orgFeatures, 'name'), 'org-access-controls')) {
     if (!permissions) error.exit(1, 'Missing argument: permissions')
 
     if (context.flags.privileges) cli.warn('DEPRECATION WARNING: use `--permissions` not `--privileges`')

--- a/commands/access/index.js
+++ b/commands/access/index.js
@@ -5,17 +5,13 @@ let extend = require('util')._extend
 let _ = require('lodash')
 let Utils = require('../../lib/utils')
 let co = require('co')
-let orgFlags
 
-function orgHasGranularPermissions (orgFlags) {
-  return _.includes(orgFlags, 'org-access-controls') || _.includes(orgFlags, 'static-permissions')
-}
 function printJSON (collaborators) {
   cli.log(JSON.stringify(collaborators, null, 2))
 }
 
 function printAccess (app, collaborators) {
-  let showPermissions = Utils.isOrgApp(app.owner.email) && (orgHasGranularPermissions(orgFlags))
+  let showPermissions = Utils.isOrgApp(app.owner.email)
   collaborators = _.chain(collaborators)
     .sortBy(c => c.email || c.user.email)
     .reject(c => /herokumanager\.com$/.test(c.user.email))
@@ -48,31 +44,23 @@ function * run (context, heroku) {
 
   if (isOrgApp) {
     let orgName = Utils.getOwner(app.owner.email)
-    let orgInfo = yield heroku.request({
-      method: 'GET',
-      path: `/v1/organization/${orgName}`,
-      headers: { Accept: 'application/vnd.heroku+json; version=2' }
-    })
 
-    orgFlags = orgInfo.flags
-    if (orgHasGranularPermissions(orgFlags)) {
-      try {
-        let admins = yield heroku.get(`/organizations/${orgName}/members`)
-        admins = _.filter(admins, { 'role': 'admin' })
+    try {
+      let admins = yield heroku.get(`/organizations/${orgName}/members`)
+      admins = _.filter(admins, { 'role': 'admin' })
 
-        let adminPermissions = yield heroku.get('/organizations/permissions')
+      let adminPermissions = yield heroku.get('/organizations/permissions')
 
-        admins = _.forEach(admins, function (admin) {
-          admin.user = { email: admin.email }
-          admin.permissions = adminPermissions
-          return admin
-        })
+      admins = _.forEach(admins, function (admin) {
+        admin.user = { email: admin.email }
+        admin.permissions = adminPermissions
+        return admin
+      })
 
-        collaborators = _.reject(collaborators, {role: 'admin'}) // Admins might have already permissions
-        collaborators = _.union(collaborators, admins)
-      } catch (err) {
-        if (err.statusCode !== 403) throw err
-      }
+      collaborators = _.reject(collaborators, {role: 'admin'}) // Admins might have already permissions
+      collaborators = _.union(collaborators, admins)
+    } catch (err) {
+      if (err.statusCode !== 403) throw err
     }
   }
 

--- a/commands/access/index.js
+++ b/commands/access/index.js
@@ -39,8 +39,7 @@ function * run (context, heroku) {
 
   let app = yield heroku.get(`/apps/${appName}`)
   let isOrgApp = Utils.isOrgApp(app.owner.email)
-  const path = isOrgApp ? `/organizations/apps/${appName}/collaborators` : `/apps/${appName}/collaborators`
-  let collaborators = yield heroku.get(path)
+  let collaborators = yield heroku.get(`/apps/${appName}/collaborators`)
 
   if (isOrgApp) {
     let orgName = Utils.getOwner(app.owner.email)

--- a/test/commands/access/add.js
+++ b/test/commands/access/add.js
@@ -7,17 +7,17 @@ let assertExit = require('../../assert_exit')
 let unwrap = require('../../unwrap')
 let stubGet = require('../../stub/get')
 let stubPost = require('../../stub/post')
-let api
-let apiPermissionsVariant
-let apiV2
+let apiGet
+let apiPost
+let apiGetOrgFeatures
 
 describe('heroku access:add', () => {
   context('with an org app with user permissions', () => {
     beforeEach(() => {
       cli.mockConsole()
-      api = stubGet.orgApp()
-      apiPermissionsVariant = stubPost.collaboratorsWithPermissions(['deploy', 'view'])
-      apiV2 = stubGet.orgFlags(['org-access-controls'])
+      apiGet = stubGet.orgApp()
+      apiPost = stubPost.collaboratorsWithPermissions(['deploy', 'view'])
+      apiGetOrgFeatures = stubGet.orgFeatures([{ name: 'org-access-controls' }])
     })
     afterEach(() => nock.cleanAll())
 
@@ -26,9 +26,9 @@ describe('heroku access:add', () => {
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiV2.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGet.done())
+        .then(() => apiGetOrgFeatures.done())
+        .then(() => apiPost.done())
     })
 
     it('adds user to the app with permissions, even specifying the view permission', () => {
@@ -36,9 +36,9 @@ describe('heroku access:add', () => {
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiV2.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGet.done())
+        .then(() => apiGetOrgFeatures.done())
+        .then(() => apiPost.done())
     })
 
     it('raises an error when permissions are not specified', () => {
@@ -47,9 +47,9 @@ describe('heroku access:add', () => {
       return assertExit(1, cmd.run({
         app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: {}
       }).then(() => {
-        api.done()
-        apiV2.done()
-        apiPermissionsVariant.done()
+        apiGet.done()
+        apiGetOrgFeatures.done()
+        apiPost.done()
       })).then(function () {
         expect(unwrap(cli.stderr)).to.equal(` ▸    Missing argument: permissions
 `)
@@ -66,9 +66,9 @@ describe('heroku access:add', () => {
   context('with an org app without user permissions', () => {
     beforeEach(() => {
       cli.mockConsole()
-      api = stubGet.orgApp()
-      apiPermissionsVariant = stubPost.collaborators()
-      apiV2 = stubGet.orgFlags([])
+      apiGet = stubGet.orgApp()
+      apiPost = stubPost.collaborators()
+      apiGetOrgFeatures = stubGet.orgFeatures([])
     })
     afterEach(() => nock.cleanAll())
 
@@ -77,17 +77,17 @@ describe('heroku access:add', () => {
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding raulb@heroku.com access to the app myapp... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiV2.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGet.done())
+        .then(() => apiGetOrgFeatures.done())
+        .then(() => apiPost.done())
     })
   })
 
   context('with a non org app', () => {
     beforeEach(() => {
       cli.mockConsole()
-      api = stubGet.personalApp()
-      apiPermissionsVariant = stubPost.collaborators()
+      apiGet = stubGet.personalApp()
+      apiPost = stubPost.collaborators()
     })
     afterEach(() => nock.cleanAll())
 
@@ -96,8 +96,8 @@ describe('heroku access:add', () => {
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding raulb@heroku.com access to the app myapp... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGet.done())
+        .then(() => apiPost.done())
     })
   })
 })

--- a/test/commands/access/index.js
+++ b/test/commands/access/index.js
@@ -10,8 +10,8 @@ describe('heroku access', () => {
     afterEach(() => nock.cleanAll())
 
     it('shows the app collaborators', () => {
-      let apiPersonalApp = stubGet.personalApp()
-      let apiAppCollaborators = stubGet.appCollaborators()
+      let apiGetPersonalApp = stubGet.personalApp()
+      let apiGetAppCollaborators = stubGet.appCollaborators()
 
       return cmd.run({app: 'myapp', flags: {}})
         .then(() => expect(
@@ -19,42 +19,20 @@ describe('heroku access', () => {
 raulb@heroku.com  owner
 `).to.eq(cli.stdout))
         .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiPersonalApp.done())
-        .then(() => apiAppCollaborators.done())
+        .then(() => apiGetPersonalApp.done())
+        .then(() => apiGetAppCollaborators.done())
     })
   })
 
-  context('with a role based access controls org', () => {
+  context('with an enterprise organization', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
     it('shows the app collaborators and hides the org collaborator record', () => {
-      let apiOrgApp = stubGet.orgApp()
-      let apiOrgAppCollaborators = stubGet.orgAppCollaborators()
-      let apiOrgFlags = stubGet.orgFlags('')
-
-      return cmd.run({app: 'myapp', flags: {}})
-        .then(() => expect(
-          `bob@heroku.com    collaborator
-raulb@heroku.com  admin
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiOrgApp.done())
-        .then(() => apiOrgAppCollaborators.done())
-        .then(() => apiOrgFlags.done())
-    })
-  })
-
-  context('with a org with static permissions', () => {
-    beforeEach(() => cli.mockConsole())
-    afterEach(() => nock.cleanAll())
-
-    it('shows the app collaborators and hides the org collaborator record', () => {
-      let apiOrgApp = stubGet.orgApp()
-      let apiOrgMembers = stubGet.orgMembers()
-      let apiAppPermissions = stubGet.appPermissions()
-      let apiOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
-      let apiOrgFlags = stubGet.orgFlags('static-permissions')
+      let apiGetOrgApp = stubGet.orgApp()
+      let apiGetOrgMembers = stubGet.orgMembers()
+      let apiGetAppPermissions = stubGet.appPermissions()
+      let apiGetOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
 
       return cmd.run({app: 'myapp', flags: {}})
         .then(() => expect(
@@ -62,24 +40,22 @@ raulb@heroku.com  admin
 raulb@heroku.com  admin   deploy,manage,operate,view
 `).to.eq(cli.stdout))
         .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiOrgApp.done())
-        .then(() => apiOrgMembers.done())
-        .then(() => apiAppPermissions.done())
-        .then(() => apiOrgAppCollaboratorsWithPermissions.done())
-        .then(() => apiOrgFlags.done())
+        .then(() => apiGetOrgApp.done())
+        .then(() => apiGetOrgMembers.done())
+        .then(() => apiGetAppPermissions.done())
+        .then(() => apiGetOrgAppCollaboratorsWithPermissions.done())
     })
   })
 
-  context('with a org with dynamic permissions', () => {
+  context('with an organization', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
     it('shows the app collaborators and hides the org collaborator record', () => {
-      let apiOrgApp = stubGet.orgApp()
-      let apiOrgMembers = stubGet.orgMembers()
-      let apiAppPermissions = stubGet.appPermissions()
-      let apiOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
-      let apiOrgFlags = stubGet.orgFlags('org-access-controls')
+      let apiGetOrgApp = stubGet.orgApp()
+      let apiGetOrgMembers = stubGet.orgMembers()
+      let apiGetAppPermissions = stubGet.appPermissions()
+      let apiGetOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
 
       return cmd.run({app: 'myapp', flags: {}})
         .then(() => expect(
@@ -87,11 +63,10 @@ raulb@heroku.com  admin   deploy,manage,operate,view
 raulb@heroku.com  admin   deploy,manage,operate,view
 `).to.eq(cli.stdout))
         .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiOrgApp.done())
-        .then(() => apiOrgMembers.done())
-        .then(() => apiAppPermissions.done())
-        .then(() => apiOrgAppCollaboratorsWithPermissions.done())
-        .then(() => apiOrgFlags.done())
+        .then(() => apiGetOrgApp.done())
+        .then(() => apiGetOrgMembers.done())
+        .then(() => apiGetAppPermissions.done())
+        .then(() => apiGetOrgAppCollaboratorsWithPermissions.done())
     })
   })
 })

--- a/test/commands/access/index.js
+++ b/test/commands/access/index.js
@@ -24,30 +24,7 @@ raulb@heroku.com  owner
     })
   })
 
-  context('with an enterprise organization', () => {
-    beforeEach(() => cli.mockConsole())
-    afterEach(() => nock.cleanAll())
-
-    it('shows the app collaborators and hides the org collaborator record', () => {
-      let apiGetOrgApp = stubGet.orgApp()
-      let apiGetOrgMembers = stubGet.orgMembers()
-      let apiGetAppPermissions = stubGet.appPermissions()
-      let apiGetOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
-
-      return cmd.run({app: 'myapp', flags: {}})
-        .then(() => expect(
-          `bob@heroku.com    member  deploy,view
-raulb@heroku.com  admin   deploy,manage,operate,view
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgApp.done())
-        .then(() => apiGetOrgMembers.done())
-        .then(() => apiGetAppPermissions.done())
-        .then(() => apiGetOrgAppCollaboratorsWithPermissions.done())
-    })
-  })
-
-  context('with an organization', () => {
+  context('with organization/team', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 

--- a/test/commands/access/remove.js
+++ b/test/commands/access/remove.js
@@ -3,13 +3,13 @@
 
 let cmd = require('../../../commands/access/remove')
 let stubDelete = require('../../stub/delete')
-let api
+let apiDelete
 
 describe('heroku access:remove', () => {
   context('with either a personal or org app', () => {
     beforeEach(() => {
       cli.mockConsole()
-      api = stubDelete.collaboratorsPersonalApp('myapp', 'raulb@heroku.com')
+      apiDelete = stubDelete.collaboratorsPersonalApp('myapp', 'raulb@heroku.com')
     })
     afterEach(() => nock.cleanAll())
 
@@ -18,7 +18,7 @@ describe('heroku access:remove', () => {
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Removing raulb@heroku.com access from the app myapp... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
+        .then(() => apiDelete.done())
     })
   })
 })

--- a/test/commands/access/update.js
+++ b/test/commands/access/update.js
@@ -5,6 +5,10 @@ let cmd = require('../../../commands/access/update')
 let error = require('../../../lib/error')
 let assertExit = require('../../assert_exit')
 let unwrap = require('../../unwrap')
+let stubPatch = require('../../stub/patch')
+let stubGet = require('../../stub/get')
+let apiPatchAppCollaborators
+let apiGetApp
 
 describe('heroku access:update', () => {
   context('with an org app with permissions', () => {
@@ -12,68 +16,38 @@ describe('heroku access:update', () => {
     afterEach(() => nock.cleanAll())
 
     it('updates the app permissions, view being implicit', () => {
-      let api = nock('https://api.heroku.com:443')
-        .get('/apps/myapp')
-        .reply(200, {
-          name: 'myapp',
-          owner: { email: 'myorg@herokumanager.com' }
-        })
-      let apiPermissionsVariant = nock('https://api.heroku.com:443', {
-        reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
-      })
-        .patch('/organizations/apps/myapp/collaborators/raulb@heroku.com', {
-          permissions: ['deploy', 'view']
-        }).reply(200)
+      apiGetApp = stubGet.orgApp()
+      apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({email: 'raulb@heroku.com', permissions: ['deploy', 'view']})
 
       return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { permissions: 'deploy' }})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Updating raulb@heroku.com in application myapp with deploy,view permissions... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGetApp.done())
+        .then(() => apiPatchAppCollaborators.done())
     })
 
     it('updates the app permissions, even specifying view as a permission', () => {
-      let api = nock('https://api.heroku.com:443')
-        .get('/apps/myapp')
-        .reply(200, {
-          name: 'myapp',
-          owner: { email: 'myorg@herokumanager.com' }
-        })
-      let apiPermissionsVariant = nock('https://api.heroku.com:443', {
-        reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
-      })
-        .patch('/organizations/apps/myapp/collaborators/raulb@heroku.com', {
-          permissions: ['deploy', 'view']
-        }).reply(200)
+      apiGetApp = stubGet.orgApp()
+      apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({email: 'raulb@heroku.com', permissions: ['deploy', 'view']})
 
       return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { permissions: 'deploy,view' }})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Updating raulb@heroku.com in application myapp with deploy,view permissions... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGetApp.done())
+        .then(() => apiPatchAppCollaborators.done())
     })
 
     it('supports --privileges, but shows deprecation warning', () => {
-      let api = nock('https://api.heroku.com:443')
-        .get('/apps/myapp')
-        .reply(200, {
-          name: 'myapp',
-          owner: { email: 'myorg@herokumanager.com' }
-        })
-      let apiPermissionsVariant = nock('https://api.heroku.com:443', {
-        reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
-      })
-        .patch('/organizations/apps/myapp/collaborators/raulb@heroku.com', {
-          permissions: ['deploy', 'view']
-        }).reply(200)
+      apiGetApp = stubGet.orgApp()
+      apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({email: 'raulb@heroku.com', permissions: ['deploy', 'view']})
 
       return cmd.run({app: 'myapp', args: {email: 'raulb@heroku.com'}, flags: { privileges: 'deploy' }})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(' ▸    DEPRECATION WARNING: use `--permissions` not `--privileges`\nUpdating raulb@heroku.com in application myapp with deploy,view permissions... done\n').to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => apiPermissionsVariant.done())
+        .then(() => apiGetApp.done())
+        .then(() => apiPatchAppCollaborators.done())
     })
   })
 
@@ -85,18 +59,13 @@ describe('heroku access:update', () => {
     afterEach(() => nock.cleanAll())
 
     it('returns an error when passing permissions', () => {
-      let api = nock('https://api.heroku.com:443')
-        .get('/apps/myapp')
-        .reply(200, {
-          name: 'myapp',
-          owner: { email: 'raulb@heroku.com' }
-        })
+      apiGetApp = stubGet.personalApp()
 
       return assertExit(1, cmd.run({
         app: 'myapp',
         args: {email: 'raulb@heroku.com'},
         flags: { permissions: 'view,deploy' }
-      }).then(() => api.done())).then(function () {
+      }).then(() => apiGetApp.done())).then(function () {
         expect(unwrap(cli.stderr)).to.equal(` ▸    Error: cannot update permissions. The app myapp is not owned by an organization
 `)
       })

--- a/test/commands/apps/lock.js
+++ b/test/commands/apps/lock.js
@@ -8,7 +8,7 @@ describe('heroku apps:lock', () => {
   afterEach(() => nock.cleanAll())
 
   it('locks the app', () => {
-    let api = nock('https://api.heroku.com:443')
+    let apiGetApp = nock('https://api.heroku.com:443')
       .get('/organizations/apps/myapp')
       .reply(200, {name: 'myapp', locked: false})
       .patch('/organizations/apps/myapp', {locked: true})
@@ -17,6 +17,6 @@ describe('heroku apps:lock', () => {
       .then(() => expect('').to.eq(cli.stdout))
       .then(() => expect(`Locking myapp... done
 `).to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetApp.done())
   })
 })

--- a/test/commands/members/add.js
+++ b/test/commands/members/add.js
@@ -3,23 +3,25 @@
 
 let cmd = require('../../../commands/members/add').add
 let stubGet = require('../../stub/get')
+let stubPut = require('../../stub/put')
+
 
 describe('heroku members:add', () => {
+  let apiUpdateMemberRole
+
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
   it('adds a member to an org', () => {
     stubGet.variableSizeOrgMembers(1)
     stubGet.userFeatureFlags([])
-    let api = nock('https://api.heroku.com:443')
-      .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
-      .reply(200)
+    apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
     return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
       .then(() => expect('').to.eq(cli.stdout))
       .then(() => expect(`Adding foo@foo.com to myorg as admin... done
 `).to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiUpdateMemberRole.done())
   })
 
   context('adding a member with the standard org creation flag', () => {
@@ -29,42 +31,36 @@ describe('heroku members:add', () => {
 
     it('does not warn the user when under the free org limit', () => {
       stubGet.variableSizeOrgMembers(1)
-      let api = nock('https://api.heroku.com:443')
-        .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
-        .reply(200)
+      apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
       return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding foo@foo.com to myorg as admin... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
+        .then(() => apiUpdateMemberRole.done())
     })
 
     it('does not warn the user when over the free org limit', () => {
       stubGet.variableSizeOrgMembers(7)
-      let api = nock('https://api.heroku.com:443')
-        .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
-        .reply(200)
+      apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
       return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding foo@foo.com to myorg as admin... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
+        .then(() => apiUpdateMemberRole.done())
     })
 
     it('does warn the user when at the free org limit', () => {
       stubGet.variableSizeOrgMembers(6)
-      let api = nock('https://api.heroku.com:443')
-        .put('/organizations/myorg/members', {email: 'foo@foo.com', role: 'admin'})
-        .reply(200)
+      apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
       return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}, flags: {role: 'admin'}})
         .then(() => expect(`You'll be billed monthly for teams over 5 members.
 `).to.eq(cli.stdout))
         .then(() => expect(`Adding foo@foo.com to myorg as admin... done
 `).to.eq(cli.stderr))
-        .then(() => api.done())
+        .then(() => apiUpdateMemberRole.done())
     })
   })
 })

--- a/test/commands/members/index.js
+++ b/test/commands/members/index.js
@@ -2,81 +2,66 @@
 /* globals describe it beforeEach afterEach cli nock expect */
 
 let cmd = require('../../../commands/members')
+let stubGet = require('../../stub/get')
 
 describe('heroku members', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
+  let apiGetOrgMembers
+
   it('shows there are not org members if it is an orphan org', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/organizations/myorg/members')
-      .reply(200, [])
+    apiGetOrgMembers = stubGet.orgMembers([])
     return cmd.run({org: 'myorg', flags: {}})
       .then(() => expect(
         `No members in myorg
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetOrgMembers.done())
   })
 
   it('shows all the org members', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/organizations/myorg/members')
-      .reply(200, [
-        {email: 'a@heroku.com', role: 'admin'},
-        {email: 'b@heroku.com', role: 'collaborator'}
-      ])
+    apiGetOrgMembers = stubGet.orgMembers([
+      {email: 'a@heroku.com', role: 'admin'}, {email: 'b@heroku.com', role: 'collaborator'}
+    ])
     return cmd.run({org: 'myorg', flags: {}})
       .then(() => expect(
         `a@heroku.com  admin
 b@heroku.com  collaborator
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetOrgMembers.done())
   })
 
+  let expectedOrgMembers = [{email: 'a@heroku.com', role: 'admin'}, {email: 'b@heroku.com', role: 'member'}]
+
   it('filters members by role', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/organizations/myorg/members')
-      .reply(200, [
-        {email: 'a@heroku.com', role: 'admin'},
-        {email: 'b@heroku.com', role: 'member'}
-      ])
+    apiGetOrgMembers = stubGet.orgMembers(expectedOrgMembers)
     return cmd.run({org: 'myorg', flags: {role: 'member'}})
       .then(() => expect(
         `b@heroku.com  member
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetOrgMembers.done())
   })
 
   it("shows the right message when filter doesn't return results", () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/organizations/myorg/members')
-      .reply(200, [
-        {email: 'a@heroku.com', role: 'admin'},
-        {email: 'b@heroku.com', role: 'member'}
-      ])
+    apiGetOrgMembers = stubGet.orgMembers(expectedOrgMembers)
     return cmd.run({org: 'myorg', flags: {role: 'collaborator'}})
       .then(() => expect(
         `No members in myorg with role collaborator
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetOrgMembers.done())
   })
 
   it('filters members by role', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/organizations/myorg/members')
-      .reply(200, [
-        {email: 'a@heroku.com', role: 'admin'},
-        {email: 'b@heroku.com', role: 'member'}
-      ])
+    apiGetOrgMembers = stubGet.orgMembers(expectedOrgMembers)
     return cmd.run({org: 'myorg', flags: {role: 'member'}})
       .then(() => expect(
         `b@heroku.com  member
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetOrgMembers.done())
   })
 })

--- a/test/commands/members/remove.js
+++ b/test/commands/members/remove.js
@@ -2,19 +2,18 @@
 /* globals describe it beforeEach afterEach cli nock expect */
 
 let cmd = require('../../../commands/members/remove')
+let stubDelete = require('../../stub/delete')
 
 describe('heroku members:remove', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
   it('removes a member from an org', () => {
-    let api = nock('https://api.heroku.com:443')
-      .delete('/organizations/myorg/members/foo%40foo.com')
-      .reply(200)
+    let apiRemoveMemberFromOrg = stubDelete.memberFromOrg()
     return cmd.run({org: 'myorg', args: {email: 'foo@foo.com'}})
       .then(() => expect('').to.eq(cli.stdout))
       .then(() => expect(`Removing foo@foo.com from myorg... done
 `).to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiRemoveMemberFromOrg.done())
   })
 })

--- a/test/commands/orgs/index.js
+++ b/test/commands/orgs/index.js
@@ -2,24 +2,21 @@
 /* globals describe it beforeEach afterEach cli nock expect */
 
 let cmd = require('../../../commands/orgs')
+let stubGet = require('../../stub/get')
 
 describe('heroku orgs', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
   it('shows the orgs', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/organizations')
-      .reply(200, [
-        {name: 'org a', role: 'collaborator'},
-        {name: 'org b', role: 'admin'}
-      ])
+    let apiGetOrgs = stubGet.orgs()
+
     return cmd.run({flags: {}})
       .then(() => expect(
         `org a         collaborator
 org b         admin
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => api.done())
+      .then(() => apiGetOrgs.done())
   })
 })

--- a/test/stub/delete.js
+++ b/test/stub/delete.js
@@ -14,7 +14,13 @@ function collaboratorsPersonalApp (app, email) {
     .delete(`/apps/${app}/collaborators/${email}`).reply(200, {})
 }
 
+function memberFromOrg () {
+  return nock('https://api.heroku.com:443', {})
+    .delete('/organizations/myorg/members/foo%40foo.com').reply(200)
+}
+
 module.exports = {
-  collaboratorsOrgApp: collaboratorsOrgApp,
-  collaboratorsPersonalApp: collaboratorsPersonalApp
+  collaboratorsOrgApp,
+  collaboratorsPersonalApp,
+  memberFromOrg
 }

--- a/test/stub/get.js
+++ b/test/stub/get.js
@@ -34,6 +34,15 @@ function appPermissions () {
     ])
 }
 
+function orgs (orgs = [
+  {name: 'org a', role: 'collaborator'},
+  {name: 'org b', role: 'admin'}
+]) {
+  return nock('https://api.heroku.com:443')
+    .get('/organizations')
+    .reply(200, orgs)
+}
+
 function orgApp (locked = false) {
   return nock('https://api.heroku.com:443')
     .get('/apps/myapp')
@@ -91,23 +100,23 @@ function orgFeatures (features) {
     .reply(200, features)
 }
 
-function orgMembers () {
+function orgMembers (members = [
+  {
+    email: 'raulb@heroku.com', role: 'admin',
+    user: { email: 'raulb@heroku.com' }
+  },
+  {
+    email: 'bob@heroku.com', role: 'viewer',
+    user: { email: 'bob@heroku.com' }
+  },
+  {
+    email: 'peter@heroku.com', role: 'collaborator',
+    user: { email: 'peter@heroku.com' }
+  }
+]) {
   return nock('https://api.heroku.com:443')
     .get('/organizations/myorg/members')
-    .reply(200, [
-      {
-        email: 'raulb@heroku.com', role: 'admin',
-        user: { email: 'raulb@heroku.com' }
-      },
-      {
-        email: 'bob@heroku.com', role: 'viewer',
-        user: { email: 'bob@heroku.com' }
-      },
-      {
-        email: 'peter@heroku.com', role: 'collaborator',
-        user: { email: 'peter@heroku.com' }
-      }
-    ])
+    .reply(200, members)
 }
 
 function variableSizeOrgMembers (orgSize) {
@@ -138,15 +147,16 @@ function userFeatureFlags (features) {
 }
 
 module.exports = {
-  apps: apps,
-  appCollaborators: appCollaborators,
-  appPermissions: appPermissions,
-  orgApp: orgApp,
-  orgAppCollaborators: orgAppCollaborators,
-  orgAppCollaboratorsWithPermissions: orgAppCollaboratorsWithPermissions,
-  orgFeatures: orgFeatures,
-  orgMembers: orgMembers,
-  personalApp: personalApp,
-  userFeatureFlags: userFeatureFlags,
-  variableSizeOrgMembers: variableSizeOrgMembers
+  apps,
+  appCollaborators,
+  appPermissions,
+  orgs,
+  orgApp,
+  orgAppCollaborators,
+  orgAppCollaboratorsWithPermissions,
+  orgFeatures,
+  orgMembers,
+  personalApp,
+  userFeatureFlags,
+  variableSizeOrgMembers
 }

--- a/test/stub/get.js
+++ b/test/stub/get.js
@@ -83,14 +83,12 @@ function orgAppCollaboratorsWithPermissions () {
     ])
 }
 
-function orgFlags (flags) {
+function orgFeatures (features) {
   return nock('https://api.heroku.com:443', {
-    reqheaders: {Accept: 'application/vnd.heroku+json; version=2'}
+    reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
   })
-    .get('/v1/organization/myorg')
-    .reply(200, {
-      flags: flags
-    })
+    .get('/organizations/myorg/features')
+    .reply(200, features)
 }
 
 function orgMembers () {
@@ -133,10 +131,10 @@ function personalApp () {
     })
 }
 
-function userFeatureFlags (flags) {
+function userFeatureFlags (features) {
   return nock('https://api.heroku.com:443')
     .get('/account/features')
-    .reply(200, flags)
+    .reply(200, features)
 }
 
 module.exports = {
@@ -146,7 +144,7 @@ module.exports = {
   orgApp: orgApp,
   orgAppCollaborators: orgAppCollaborators,
   orgAppCollaboratorsWithPermissions: orgAppCollaboratorsWithPermissions,
-  orgFlags: orgFlags,
+  orgFeatures: orgFeatures,
   orgMembers: orgMembers,
   personalApp: personalApp,
   userFeatureFlags: userFeatureFlags,

--- a/test/stub/get.js
+++ b/test/stub/get.js
@@ -12,13 +12,12 @@ function apps () {
     ])
 }
 
-function appCollaborators () {
+function appCollaborators (collaborators =
+  [{user: {email: 'raulb@heroku.com'}, role: 'owner'},
+  {user: {email: 'jeff@heroku.com'}, role: 'collaborator'}]) {
   return nock('https://api.heroku.com:443')
     .get('/apps/myapp/collaborators')
-    .reply(200, [
-      {user: {email: 'raulb@heroku.com'}, role: 'owner'},
-      {user: {email: 'jeff@heroku.com'}, role: 'collaborator'}
-    ])
+    .reply(200, collaborators)
 }
 
 function appPermissions () {
@@ -53,32 +52,11 @@ function orgApp (locked = false) {
     })
 }
 
-function orgAppCollaborators () {
-  return nock('https://api.heroku.com:443', {
-    reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
-  })
-    .get('/organizations/apps/myapp/collaborators')
-    .reply(200, [
-      {
-        role: 'owner',
-        user: { email: 'myorg@herokumanager.com' }
-      },
-      {
-        role: 'collaborator',
-        user: { email: 'bob@heroku.com' }
-      },
-      {
-        role: 'admin',
-        user: { email: 'raulb@heroku.com' }
-      }
-    ])
-}
-
 function orgAppCollaboratorsWithPermissions () {
   return nock('https://api.heroku.com:443', {
     reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
   })
-    .get('/organizations/apps/myapp/collaborators')
+    .get('/apps/myapp/collaborators')
     .reply(200, [
       { permissions: [],
         role: 'owner',
@@ -152,7 +130,6 @@ module.exports = {
   appPermissions,
   orgs,
   orgApp,
-  orgAppCollaborators,
   orgAppCollaboratorsWithPermissions,
   orgFeatures,
   orgMembers,

--- a/test/stub/patch.js
+++ b/test/stub/patch.js
@@ -2,6 +2,13 @@
 
 const nock = require('nock')
 
+function appCollaboratorWithPermissions (args) {
+  return nock('https://api.heroku.com:443')
+  .patch(`/organizations/apps/myapp/collaborators/${args.email}`, {
+    permissions: args.permissions
+  }).reply(200)
+}
+
 function orgAppTransfer () {
   return nock('https://api.heroku.com:443')
     .patch('/organizations/apps/myapp', { owner: 'team' })
@@ -15,6 +22,7 @@ function personalToPersonal () {
 }
 
 module.exports = {
-  orgAppTransfer: orgAppTransfer,
-  personalToPersonal: personalToPersonal
+  appCollaboratorWithPermissions,
+  orgAppTransfer,
+  personalToPersonal
 }

--- a/test/stub/post.js
+++ b/test/stub/post.js
@@ -26,7 +26,7 @@ function personalToPersonal () {
 }
 
 module.exports = {
-  collaborators: collaborators,
-  personalToPersonal: personalToPersonal,
-  collaboratorsWithPermissions: collaboratorsWithPermissions
+  collaborators,
+  personalToPersonal,
+  collaboratorsWithPermissions
 }

--- a/test/stub/put.js
+++ b/test/stub/put.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const nock = require('nock')
+
+function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
+  return nock('https://api.heroku.com:443')
+    .put('/organizations/myorg/members', {email, role})
+    .reply(200)
+}
+
+module.exports = {
+  updateMemberRole
+}


### PR DESCRIPTION
- Stops using v2 `v1/organization/org-name` endpoint and uses v3 `organizations/org-name/features` instead.
- Removes the use of this endpoint where we used to need to check for `access-controls` or `static-permissions` when RBAC organizations where around. Now we just need to check whether it's a team/org app or not for certain cases.
- Refactor all tests so they all are easier to understand and update.

Please, @naaman @eablack review.
