### PR TITLE
No need to check for app ownership

### DIFF
--- a/commands/apps/leave.js
+++ b/commands/apps/leave.js
@@ -4,13 +4,9 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
-  let app = yield heroku.get(`/apps/${context.app}`).catch(() => null)
-
-  let path = app.owner.email.endsWith('@herokumanager.com') ? '/organizations' : ''
   let request = heroku.get('/account')
     .then(function (user) {
-      path += `/apps/${context.app}/collaborators/${encodeURIComponent(user.email)}`
-      return heroku.delete(path).catch(function (err) {
+      return heroku.delete(`/apps/${context.app}/collaborators/${encodeURIComponent(user.email)}`).catch(function (err) {
         console.log(err)
         throw new Error(err.body)
       })

--- a/test/commands/apps/leave.js
+++ b/test/commands/apps/leave.js
@@ -7,48 +7,32 @@ let stubDelete = require('../../stub/delete')
 
 describe('heroku apps:leave', () => {
   let apiGetUserAccount
+  let apiDeletePersonalAppCollaborator
 
   beforeEach(() => {
     apiGetUserAccount = stubGet.userAccount()
+    apiDeletePersonalAppCollaborator = stubDelete.collaboratorsPersonalApp('myapp', 'raulb%40heroku.com')
     cli.mockConsole()
   })
   afterEach(() => nock.cleanAll())
 
   context('when it is an org app', () => {
-    let apiDeleteOrgAppCollaborator
-    let apiOrgApp
-
-    beforeEach(() => {
-      apiDeleteOrgAppCollaborator = stubDelete.collaboratorsOrgApp('myapp', 'raulb%40heroku.com')
-      apiOrgApp = stubGet.orgApp()
-    })
-
     it('leaves the app', () => {
       return cmd.run({app: 'myapp'})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Leaving myapp... done
 `).to.eq(cli.stderr))
-        .then(() => apiOrgApp.done())
         .then(() => apiGetUserAccount.done())
-        .then(() => apiDeleteOrgAppCollaborator.done())
+        .then(() => apiDeletePersonalAppCollaborator.done())
     })
   })
 
   context('when it is not an org app', () => {
-    let apiDeletePersonalAppCollaborator
-    let apiGetPersonalApp
-
-    beforeEach(() => {
-      apiDeletePersonalAppCollaborator = stubDelete.collaboratorsPersonalApp('myapp', 'raulb%40heroku.com')
-      apiGetPersonalApp = stubGet.personalApp()
-    })
-
     it('leaves the app', () => {
       return cmd.run({app: 'myapp'})
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Leaving myapp... done
 `).to.eq(cli.stderr))
-        .then(() => apiGetPersonalApp.done())
         .then(() => apiGetUserAccount.done())
         .then(() => apiDeletePersonalAppCollaborator.done())
     })


### PR DESCRIPTION
See https://github.com/heroku/heroku-orgs/issues/64#issuecomment-249034687.

```
$ h access -a whispering-reef-20864            
 ▸    You do not have permission to view on whispering-reef-20864. You need to have the view permission on this app.
$ h apps:join -a whispering-reef-20864 
Joining whispering-reef-20864... done
$ h access -a whispering-reef-20864 
naaman@heroku.com  admin   deploy,manage,operate,view
raulb@heroku.com   member  view
$ h apps:leave -a whispering-reef-20864 
Leaving whispering-reef-20864... done
$ h access -a whispering-reef-20864    
 ▸    You do not have permission to view on whispering-reef-20864. You need to have the view permission on this app.
```
