### PR TITLE
Implement team invites for those with the feature flag

### DIFF
--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -3,29 +3,69 @@
 let cli = require('heroku-cli-util')
 let co = require('co')
 let extend = require('util')._extend
+let Utils = require('../../lib/utils')
 
 function * run (context, heroku) {
-  // Users receive `You'll be billed monthly for teams over 5 members.`
-  // message when going over the FREE_TEAM_LIMIT
-  const FREE_TEAM_LIMIT = 5
-  let org = context.org
+  let orgInfo = yield Utils.orgInfo(context, heroku)
+  let orgName = context.org
+
+  const warnMembershipLimit = function * (totalMembers) {
+    // Users receive `You'll be billed monthly for teams over 5 members.`
+    if (totalMembers === 6) {
+      cli.warn("You'll be billed monthly for teams over 5 members.")
+    }
+  }
+
+  let addMemberToOrg = function * (email, role, orgName) {
+    let request = heroku.request({
+      method: 'PUT',
+      path: `/organizations/${orgName}/members`,
+      body: {email, role}
+    })
+    yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(orgName)} as ${cli.color.green(role)}`, request)
+  }
+
+  let inviteMemberToTeam = function * (email, role, orgName) {
+    let request = heroku.request({
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.team-invitations'
+      },
+      method: 'PUT',
+      path: `/organizations/${orgName}/invitations`,
+      body: {email, role}
+    }).then(request => {
+      cli.action.done('email sent')
+    })
+
+    yield cli.action(`Inviting ${cli.color.cyan(email)} to ${cli.color.magenta(orgName)} as ${cli.color.green(role)}`, request)
+  }
+
   let email = context.args.email
   let role = context.flags.role
-  let features = yield heroku.get('/account/features')
-  let orgCreationFeature = features.find(function (feature) {
-    return feature.name === 'standard-org-creation'
-  })
 
-  let request = heroku.request({
-    method: 'PUT',
-    path: `/organizations/${org}/members`,
-    body: {email, role}
-  })
-  yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(org)} as ${cli.color.green(role)}`, request)
+  let groupFeatures = yield heroku.get(`/organizations/${orgName}/features`)
 
-  let members = yield heroku.get(`/organizations/${org}/members`)
-  if ((members.length === (FREE_TEAM_LIMIT + 1)) && orgCreationFeature) {
-    cli.log("You'll be billed monthly for teams over 5 members.")
+  if (groupFeatures.filter(of => of.name === 'team-invite-acceptance').length) {
+    yield inviteMemberToTeam(email, role, orgName)
+  } else {
+    yield addMemberToOrg(email, role, orgName)
+  }
+
+  if (orgInfo.type === 'team') {
+    let membersAndInvites = yield co(function * () {
+      return yield {
+        invites: heroku.request({
+          headers: {
+            Accept: 'application/vnd.heroku+json; version=3.team-invitations'
+          },
+          method: 'GET',
+          path: `/organizations/${orgName}/invitations`
+        }),
+        members: heroku.get(`/organizations/${orgName}/members`)
+      }
+    })
+    const membersCount = membersAndInvites.invites.length + membersAndInvites.members.length
+    yield warnMembershipLimit(membersCount)
   }
 }
 

--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -11,7 +11,8 @@ function * run (context, heroku) {
 
   const warnMembershipLimit = function * (totalMembers) {
     // Users receive `You'll be billed monthly for teams over 5 members.`
-    if (totalMembers === 6) {
+    const FREE_TEAM_LIMIT = 6
+    if (totalMembers === FREE_TEAM_LIMIT) {
       cli.warn("You'll be billed monthly for teams over 5 members.")
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,9 @@ var isValidEmail = function (email) {
 
 var orgInfo = function * (context, heroku) {
   let teamOrOrgName = context.org || context.flags.team
-  if (!teamOrOrgName) error.exit(1, 'No team or org specified.\nRun this command with --team or --org')
+  if (!teamOrOrgName) {
+    error.exit(1, 'No team or org specified.\nRun this command with --team or --org')
+  }
   return yield heroku.get(`/organizations/${context.org || context.flags.team}`)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,18 @@
+let error = require('./error')
+
 var isOrgApp = function (owner) {
   return (/@herokumanager\.com$/.test(owner))
 }
-
-module.exports.isOrgApp = isOrgApp
 
 var isValidEmail = function (email) {
   return /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(email)
 }
 
-module.exports.isValidEmail = isValidEmail
+var orgInfo = function * (context, heroku) {
+  let teamOrOrgName = context.org || context.flags.team
+  if (!teamOrOrgName) error.exit(1, 'No team or org specified.\nRun this command with --team or --org')
+  return yield heroku.get(`/organizations/${context.org || context.flags.team}`)
+}
 
 var getOwner = function (owner) {
   if (isOrgApp(owner)) {
@@ -17,4 +21,9 @@ var getOwner = function (owner) {
   return owner
 }
 
-module.exports.getOwner = getOwner
+module.exports = {
+  getOwner,
+  isOrgApp,
+  isValidEmail,
+  orgInfo
+}

--- a/test/stub/get.js
+++ b/test/stub/get.js
@@ -52,6 +52,18 @@ function orgApp (locked = false) {
     })
 }
 
+function orgInfo (type = 'enterprise') {
+  return nock('https://api.heroku.com:443', {
+    reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
+  })
+    .get('/organizations/myorg')
+    .reply(200, {
+      name: 'myorg',
+      role: 'admin',
+      type: type
+    })
+}
+
 function orgAppCollaboratorsWithPermissions () {
   return nock('https://api.heroku.com:443', {
     reqheaders: {Accept: 'application/vnd.heroku+json; version=3'}
@@ -109,6 +121,21 @@ function variableSizeOrgMembers (orgSize) {
     .reply(200, orgMembers)
 }
 
+function variableSizeTeamInvites (teamSize) {
+  teamSize = (typeof (teamSize) === 'undefined') ? 1 : teamSize
+  let invites = []
+  for (let i = 0; i < teamSize; i++) {
+    invites.push({
+      role: 'member', user: { email: `invited-user-${i}@mail.com` }
+    })
+  }
+  return nock('https://api.heroku.com:443', {
+    reqheaders: {Accept: 'application/vnd.heroku+json; version=3.team-invitations'}
+  })
+    .get('/organizations/myorg/invitations')
+    .reply(200, invites)
+}
+
 function personalApp () {
   return nock('https://api.heroku.com:443')
     .get('/apps/myapp')
@@ -137,10 +164,12 @@ module.exports = {
   orgs,
   orgApp,
   orgAppCollaboratorsWithPermissions,
+  orgInfo,
   orgFeatures,
   orgMembers,
   personalApp,
   userAccount,
   userFeatureFlags,
-  variableSizeOrgMembers
+  variableSizeOrgMembers,
+  variableSizeTeamInvites
 }

--- a/test/stub/put.js
+++ b/test/stub/put.js
@@ -2,6 +2,12 @@
 
 const nock = require('nock')
 
+function sendInvite (email = 'raulb@heroku.com', role = 'admin') {
+  return nock('https://api.heroku.com:443')
+    .put('/organizations/myorg/invitations', {email, role})
+    .reply(200)
+}
+
 function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
     .put('/organizations/myorg/members', {email, role})
@@ -9,5 +15,6 @@ function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
 }
 
 module.exports = {
+  sendInvite,
   updateMemberRole
 }


### PR DESCRIPTION
This pull request only implements what's necessary for fixing an API error whenever a user operates with the command `members:add` to an org/team with the feature flag `team-invite-acceptance`. Without this Pull request, users will receive an error informing them about using the wrong API endpoint.

Other commands/improvements will be implemented separately in a separate PR after Dreamforce:

https://github.com/heroku/heroku-orgs/pull/62
