### PR TITLE
do not require arguments for moved commmands

### DIFF
--- a/commands/access/add.js
+++ b/commands/access/add.js
@@ -5,7 +5,6 @@ let _ = require('lodash')
 let Utils = require('../../lib/utils')
 let co = require('co')
 let error = require('../../lib/error')
-let extend = require('util')._extend
 
 function * run (context, heroku) {
   let appName = context.app
@@ -41,25 +40,27 @@ function * run (context, heroku) {
   yield cli.action(`${output}`, request)
 }
 
-let cmd = {
-  topic: 'access',
-  needsAuth: true,
-  needsApp: true,
-  command: 'add',
-  description: 'Add new users to your app',
-  help: 'heroku access:add user@email.com --app APP # Add a collaborator to your app\n\nheroku access:add user@email.com --app APP --permissions deploy,manage,operate # permissions must be comma separated',
-  args: [{name: 'email', optional: false}],
-  flags: [
-    {name: 'permissions', description: 'list of permissions comma separated', hasValue: true, optional: true},
-    {name: 'privileges', hasValue: true, optional: true, hidden: true} // Deprecated flag
-  ],
-  run: cli.command(co.wrap(run))
-}
-
-module.exports = cmd
-module.exports.sharing = extend({}, cmd)
-module.exports.sharing.hidden = true
-module.exports.sharing.topic = 'sharing'
-module.exports.sharing.run = function () {
-  cli.error(`This command is now ${cli.color.cyan('heroku access:add')}`); process.exit(1)
-}
+module.exports = [
+  {
+    topic: 'access',
+    needsAuth: true,
+    needsApp: true,
+    command: 'add',
+    description: 'Add new users to your app',
+    help: 'heroku access:add user@email.com --app APP # Add a collaborator to your app\n\nheroku access:add user@email.com --app APP --permissions deploy,manage,operate # permissions must be comma separated',
+    args: [{name: 'email', optional: false}],
+    flags: [
+      {name: 'permissions', description: 'list of permissions comma separated', hasValue: true, optional: true},
+      {name: 'privileges', hasValue: true, optional: true, hidden: true} // Deprecated flag
+    ],
+    run: cli.command(co.wrap(run))
+  }, {
+    topic: 'sharing',
+    command: 'add',
+    hidden: true,
+    run: () => {
+      cli.error(`This command is now ${cli.color.cyan('heroku access:add')}`)
+      process.exit(1)
+    }
+  }
+]

--- a/commands/access/index.js
+++ b/commands/access/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let extend = require('util')._extend
 let _ = require('lodash')
 let Utils = require('../../lib/utils')
 let co = require('co')
@@ -67,22 +66,24 @@ function * run (context, heroku) {
   else printAccess(app, collaborators)
 }
 
-let cmd = {
-  topic: 'access',
-  description: 'list who has access to an app',
-  needsAuth: true,
-  needsApp: true,
-  flags: [
-    {name: 'json', description: 'output in json format'}
-  ],
-  run: cli.command(co.wrap(run))
-}
-
-module.exports = cmd
-module.exports.sharing = extend({}, cmd)
-module.exports.sharing.hidden = true
-module.exports.sharing.topic = 'sharing'
-module.exports.sharing.run = function () {
-  cli.error(`This command is now ${cli.color.cyan('heroku access')}`)
-  process.exit(1)
-}
+module.exports = [
+  {
+    topic: 'access',
+    description: 'list who has access to an app',
+    needsAuth: true,
+    needsApp: true,
+    flags: [
+      {name: 'json', description: 'output in json format'}
+    ],
+    run: cli.command(co.wrap(run))
+  },
+  {
+    topic: 'sharing',
+    command: 'access',
+    hidden: true,
+    run: () => {
+      cli.error(`This command is now ${cli.color.cyan('heroku access')}`)
+      process.exit(1)
+    }
+  }
+]

--- a/commands/access/remove.js
+++ b/commands/access/remove.js
@@ -2,7 +2,6 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
-let extend = require('util')._extend
 
 function * run (context, heroku) {
   let appName = context.app
@@ -10,21 +9,24 @@ function * run (context, heroku) {
   yield cli.action(`Removing ${cli.color.cyan(context.args.email)} access from the app ${cli.color.magenta(appName)}`, request)
 }
 
-let cmd = {
-  topic: 'access',
-  needsAuth: true,
-  needsApp: true,
-  command: 'remove',
-  description: 'Remove users from your app',
-  help: 'heroku access:remove user@email.com --app APP',
-  args: [{name: 'email', optional: false}],
-  run: cli.command(co.wrap(run))
-}
-
-module.exports = cmd
-module.exports.sharing = extend({}, cmd)
-module.exports.sharing.hidden = true
-module.exports.sharing.topic = 'sharing'
-module.exports.sharing.run = function () {
-  cli.error(`This command is now ${cli.color.cyan('heroku access:remove')}`); process.exit(1)
-}
+module.exports = [
+  {
+    topic: 'access',
+    needsAuth: true,
+    needsApp: true,
+    command: 'remove',
+    description: 'Remove users from your app',
+    help: 'heroku access:remove user@email.com --app APP',
+    args: [{name: 'email', optional: false}],
+    run: cli.command(co.wrap(run))
+  },
+  {
+    topic: 'sharing',
+    command: 'remove',
+    hidden: true,
+    run: () => {
+      cli.error(`This command is now ${cli.color.cyan('heroku access:remove')}`)
+      process.exit(1)
+    }
+  }
+]

--- a/commands/apps/join.js
+++ b/commands/apps/join.js
@@ -23,5 +23,5 @@ let cmd = {
   run: cli.command(co.wrap(run))
 }
 
-module.exports.apps = cmd
-module.exports.root = Object.assign({}, cmd, {topic: 'join', command: null})
+let root = Object.assign({}, cmd, {topic: 'join', command: null})
+module.exports = [cmd, root]

--- a/commands/apps/transfer.js
+++ b/commands/apps/transfer.js
@@ -4,7 +4,6 @@ let _ = require('lodash')
 let AppTransfer = require('../../lib/app_transfer')
 let cli = require('heroku-cli-util')
 let co = require('co')
-let extend = require('util')._extend
 let inquirer = require('inquirer')
 let lock = require('./lock.js').apps
 let Utils = require('../../lib/utils')
@@ -100,10 +99,12 @@ Examples:
 }
 
 module.exports = cmd
-module.exports.sharing = extend({}, cmd)
-module.exports.sharing.hidden = true
-module.exports.sharing.topic = 'sharing'
-module.exports.sharing.run = function () {
-  cli.error(`This command is now ${cli.color.cyan('heroku apps:transfer')}`)
-  process.exit(1)
+module.exports.sharing = {
+  topic: 'sharing',
+  command: 'transfer',
+  hidden: true,
+  run: () => {
+    cli.error(`This command is now ${cli.color.cyan('heroku apps:transfer')}`)
+    process.exit(1)
+  }
 }

--- a/commands/members/add.js
+++ b/commands/members/add.js
@@ -2,7 +2,6 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
-let extend = require('util')._extend
 let Utils = require('../../lib/utils')
 
 function * run (context, heroku) {
@@ -72,7 +71,7 @@ function * run (context, heroku) {
   Utils.warnUsingOrgFlagInTeams(orgInfo, context)
 }
 
-let cmd = {
+let add = {
   topic: 'members',
   command: 'add',
   description: 'adds a user to an organization or a team',
@@ -86,7 +85,6 @@ let cmd = {
   run: cli.command(co.wrap(run))
 }
 
-module.exports.add = cmd
-module.exports.set = extend({}, cmd)
-module.exports.set.command = 'set'
-module.exports.set.description = 'sets a members role in an organization or a team'
+let set = Object.assign({}, add, {command: 'set', description: 'sets a members role in an organization or a team'})
+
+module.exports = [add, set]

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
+'use strict'
+
+const flatten = require('lodash.flatten')
+
 exports.topics = [
   {name: 'access', description: 'manage user access to apps'},
   {name: 'orgs', description: 'manage organizations'},
+  {name: 'members', description: 'manage organization members'},
+  {name: 'teams', description: 'manage teams'},
   {name: 'sharing', hidden: true},
   {name: 'join', hidden: true},
   {name: 'leave', hidden: true},
@@ -8,30 +14,21 @@ exports.topics = [
   {name: 'unlock', hidden: true}
 ]
 
-exports.commands = [
+exports.commands = flatten([
   require('./commands/access'),
-  require('./commands/access').sharing,
   require('./commands/access/add'),
-  require('./commands/access/add').sharing,
   require('./commands/access/remove'),
-  require('./commands/access/remove').sharing,
   require('./commands/access/update'),
-  require('./commands/apps/join').apps,
-  require('./commands/apps/join').root,
-  require('./commands/apps/leave').apps,
-  require('./commands/apps/leave').root,
-  require('./commands/apps/lock').apps,
-  require('./commands/apps/lock').root,
+  require('./commands/apps/join'),
+  require('./commands/apps/leave'),
+  require('./commands/apps/lock'),
   require('./commands/apps/transfer'),
-  require('./commands/apps/transfer').sharing,
-  require('./commands/apps/unlock').apps,
-  require('./commands/apps/unlock').root,
+  require('./commands/apps/unlock'),
+  require('./commands/members'),
+  require('./commands/members/add'),
+  require('./commands/members/remove'),
   require('./commands/orgs'),
   require('./commands/orgs/default'),
   require('./commands/orgs/open'),
-  require('./commands/members'),
-  require('./commands/members/add').add,
-  require('./commands/members/add').set,
-  require('./commands/members/remove'),
   require('./commands/teams')
-]
+])

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "co": "4.6.0",
     "heroku-cli-util": "6.0.15",
     "inquirer": "1.1.2",
-    "lodash": "4.15.0"
+    "lodash": "4.15.0",
+    "lodash.flatten": "4.4.0"
   },
   "devDependencies": {
     "chai": "*",

--- a/test/commands/access/add.js
+++ b/test/commands/access/add.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach afterEach context cli nock expect */
 
-let cmd = require('../../../commands/access/add')
+let cmd = require('../../../commands/access/add')[0]
 let error = require('../../../lib/error')
 let assertExit = require('../../assert_exit')
 let unwrap = require('../../unwrap')

--- a/test/commands/access/index.js
+++ b/test/commands/access/index.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach afterEach context cli nock expect */
 
-let cmd = require('../../../commands/access')
+let cmd = require('../../../commands/access')[0]
 let stubGet = require('../../stub/get')
 
 describe('heroku access', () => {

--- a/test/commands/access/remove.js
+++ b/test/commands/access/remove.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach afterEach context cli nock expect*/
 
-let cmd = require('../../../commands/access/remove')
+let cmd = require('../../../commands/access/remove')[0]
 let stubDelete = require('../../stub/delete')
 let apiDelete
 

--- a/test/commands/apps/join.js
+++ b/test/commands/apps/join.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach afterEach cli nock expect */
 
-let cmd = require('../../../commands/apps/join').apps
+let cmd = require('../../../commands/apps/join')[0]
 let stubPost = require('../../stub/post')
 let stubGet = require('../../stub/get')
 

--- a/test/commands/members/add.js
+++ b/test/commands/members/add.js
@@ -1,7 +1,7 @@
 'use strict'
 /* globals describe it beforeEach afterEach cli nock expect context */
 
-let cmd = require('../../../commands/members/add').add
+let cmd = require('../../../commands/members/add')[0]
 let stubGet = require('../../stub/get')
 let stubPut = require('../../stub/put')
 


### PR DESCRIPTION
Fixes https://github.com/heroku/cli/issues/354

also refactored index to use arrays with lodash.flatten like other
plugins that use aliases